### PR TITLE
remove space in one IRI

### DIFF
--- a/changed_ontology.owl
+++ b/changed_ontology.owl
@@ -2526,7 +2526,7 @@
 <!--  -->
 <!-- http://webprotege.stanford.edu/sexual offences -->
 
-<rdf:Description rdf:about="http://webprotege.stanford.edu/sexual offences">
+<rdf:Description rdf:about="http://webprotege.stanford.edu/sexualoffences">
 	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
 	<rdfs:subClassOf rdf:resource="http://webprotege.stanford.edu/type_of_crime"/>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual offences</rdfs:label>


### PR DESCRIPTION
In order to consume .owl files in Apache Jena all spaces in IRIs must be removed